### PR TITLE
change row_limit and row_offset only if result_type is not full

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+# Superset EF
+
+This is a repository of a extended version of [Apache Superset](https://github.com/apache/superset).
+
+EF version of Superset is by extended version that applies some additional features or applies bug fixes to official functionalities.
+
+## Extension Changelog
+
+### 2023-09-26
+
+- Apply fix chart table for full table export (`csv/excel``) - https://github.com/apache/superset/pull/23554
+
+---
+# Official documentation below
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
@@ -125,7 +125,8 @@ const buildQuery: BuildQuery<TableChartFormData> = (
 
     const moreProps: Partial<QueryObject> = {};
     const ownState = options?.ownState ?? {};
-    if (formDataCopy.server_pagination) {
+
+    if (formDataCopy.result_type !== 'full' && formDataCopy.server_pagination) {
       moreProps.row_limit =
         ownState.pageSize ?? formDataCopy.server_page_length;
       moreProps.row_offset =

--- a/superset/config.py
+++ b/superset/config.py
@@ -462,7 +462,7 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     "ALERTS_ATTACH_REPORTS": True,
     # Allow users to export full CSV of table viz type.
     # This could cause the server to run out of memory or compute.
-    "ALLOW_FULL_CSV_EXPORT": False,
+    "ALLOW_FULL_CSV_EXPORT": True,
     "GENERIC_CHART_AXES": True,  # deprecated
     "ALLOW_ADHOC_SUBQUERY": False,
     "USE_ANALAGOUS_COLORS": False,


### PR DESCRIPTION
Fix full table export in build query. Do not alterate row limit and row offset if type of result is 'full'